### PR TITLE
Update nginx.conf to run over HTTP

### DIFF
--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -6,19 +6,20 @@ http {
     root /usr/share/nginx/html;
 
     server {
-        listen 8443 ssl;
+        #listen 8443 ssl;
+        listen 8443;
         server_name  localhost;
 
-        ssl_certificate "/etc/pki/tls/certs/selfsigned.crt";
-        ssl_certificate_key "/etc/pki/tls/private/selfsigned.key";
+        #ssl_certificate "/etc/pki/tls/certs/selfsigned.crt";
+        #ssl_certificate_key "/etc/pki/tls/private/selfsigned.key";
         # It is *strongly* recommended to generate unique DH parameters
         # Generate them with: openssl dhparam -out /etc/pki/nginx/dhparams.pem 2048
         #ssl_dhparam "/etc/pki/nginx/dhparams.pem";
-        ssl_session_cache shared:SSL:10m;
-        ssl_session_timeout  5m;
-        ssl_protocols TLSv1.1 TLSv1.2;
-        ssl_ciphers ALL:!LOW:!EXP:!MD5:!RC4:!aNULL:!eNULL!DH:!IDEA:!SEED:!DES:!3DES:!CAMELLIA:AESGCM:SHA256:+SHA1:+ECDH;
-        ssl_prefer_server_ciphers on;
+        #ssl_session_cache shared:SSL:10m;
+        #ssl_session_timeout  5m;
+        #ssl_protocols TLSv1.1 TLSv1.2;
+        #ssl_ciphers ALL:!LOW:!EXP:!MD5:!RC4:!aNULL:!eNULL!DH:!IDEA:!SEED:!DES:!3DES:!CAMELLIA:AESGCM:SHA256:+SHA1:+ECDH;
+        #ssl_prefer_server_ciphers on;
 
         location /d {
             proxy_pass  http://dashboard-service:3000;


### PR DESCRIPTION
removing SSL listener and config to run nginx over HTTP. Use case is for offloading SSL to a higher stack (CDN or Load Balancer) and run web tier without requiring a local cert to be present.