### PR TITLE
Added missing IAM Action to the AWS-Setup.md file

### DIFF
--- a/docs/AWS-Setup.md
+++ b/docs/AWS-Setup.md
@@ -41,6 +41,7 @@ The IAM role in each account must contain proper permissions to collect the data
         "codedeploy:Get*",
         "codedeploy:List*",
         "directconnect:Describe*",
+        "dms:DescribeAccountAttributes",
         "dynamodb:Query",
         "dynamodb:DescribeTable",
         "dynamodb:ListTables",


### PR DESCRIPTION
Noticed this was missing in the documentation when I was trying to get this up and running. Boto3 was throwing a hard error on a missing IAM Action in the assumed role's policy.